### PR TITLE
Pass Vectors Between RTXI IO blocks

### DIFF
--- a/plugins/analogy_device/analogy_device.cpp
+++ b/plugins/analogy_device/analogy_device.cpp
@@ -570,7 +570,7 @@ void AnalogyDevice::read(void)
 		if(subdevice[DIO].chan[i].active && subdevice[DIO].chan[i].digital.direction == DAQ::INPUT)
 		{
 			mask = (1<<i);
-			output(i+offset) = (data & mask) == 0 ? 0 : 5;
+			output(i+offset) = (data & mask) == 0 ? 0.0 : 5.0;
 		}
 }
 

--- a/plugins/analogy_device/analogy_device.cpp
+++ b/plugins/analogy_device/analogy_device.cpp
@@ -570,7 +570,7 @@ void AnalogyDevice::read(void)
 		if(subdevice[DIO].chan[i].active && subdevice[DIO].chan[i].digital.direction == DAQ::INPUT)
 		{
 			mask = (1<<i);
-			output(i+offset) = (data & mask) == 0 ? 0.0 : 5.0;
+			output(i+offset) = (data & mask) == 0 ? 0 : 5;
 		}
 }
 

--- a/plugins/data_recorder/data_recorder.cpp
+++ b/plugins/data_recorder/data_recorder.cpp
@@ -625,7 +625,7 @@ void DataRecorder::Panel::execute(void)
 
             size_t n = 0;
             token.type = SYNC;
-            token.size = channels.size() * sizeof(double);
+            token.size = nChan.load() * sizeof(double);
             for (RT::List<Channel>::iterator i = channels.begin(), end = channels.end(); i != end; ++i)
                 if (i->block) {
                     const rtxi::Vector<double>& data_block = i->block->getValue(i->type, i->index);

--- a/plugins/data_recorder/data_recorder.cpp
+++ b/plugins/data_recorder/data_recorder.cpp
@@ -28,6 +28,7 @@
 #include <data_recorder.h>
 #include <iostream>
 #include <pthread.h>
+#include <iomanip>
 
 #define QFileExistsEvent            (QEvent::User+0)
 #define QSetFileNameEditEvent       (QEvent::User+1)
@@ -1500,7 +1501,7 @@ int DataRecorder::Panel::startRecording(long long timestamp)
     size_t count = 0;
     for (RT::List<Channel>::iterator i = channels.begin(), end = channels.end(); i != end; ++i)
         {
-            std::size_t chanDim = i->block->getValue(i->index).size(); // number of dims per "channel"
+            std::size_t chanDim = i->block->getValue(i->type, i->index).size(); // number of dims per "channel"
 
             for (std::size_t k=0; k<chanDim; ++k)
             {

--- a/plugins/data_recorder/data_recorder.h
+++ b/plugins/data_recorder/data_recorder.h
@@ -108,7 +108,7 @@ public:
     // mfbolus 2021/05:
     void countChannels(void); // get the *actual* channel count, checking for
                               // vectors.
-    bool getRecording() const {return recording;}; // so other plugins can know
+    bool isRecording() const {return recording;}; // so other plugins can know
                                                    // when *not* to change
                                                    // vector dimensions
 public slots:

--- a/plugins/data_recorder/data_recorder.h
+++ b/plugins/data_recorder/data_recorder.h
@@ -28,6 +28,7 @@
 #include <vector>
 #include <time.h>
 #include <daq.h>
+#include <rtxi_vector.h>
 
 #include <hdf5.h>
 #include <hdf5_hl.h>

--- a/plugins/data_recorder/data_recorder.h
+++ b/plugins/data_recorder/data_recorder.h
@@ -104,6 +104,12 @@ public:
     void receiveEvent(const Event::Object *);
     void receiveEventRT(const Event::Object *);
 
+    // mfbolus 2021/05:
+    void countChannels(void); // get the *actual* channel count, checking for
+                              // vectors.
+    bool getRecording() const {return recording;}; // so other plugins can know
+                                                   // when *not* to change
+                                                   // vector dimensions
 public slots:
     void startRecordClicked(void);
     void stopRecordClicked(void);
@@ -191,6 +197,11 @@ private:
 
     RT::List<Channel> channels;
     std::vector<IO::Block *> blockPtrList;
+
+    // TODO(mfbolus): Not sure if atomics necessary here
+    std::atomic<std::size_t> nChan; // will be the *actual* channel count,
+                                    // taking into account dimensionality of
+                                    // any vectors
 }; // class Panel
 
 class Plugin : public QObject, public ::Plugin::Object

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 CLEANFILES = *~ stamp-h?
-DISTCLEANFILES = 
+DISTCLEANFILES =
 MAINTAINERCLEANFILES = Makefile.in
 
 include $(top_srcdir)/Makefile.buildvars
@@ -24,7 +24,8 @@ pkginclude_HEADERS = \
 		rt.h \
 		sem.h \
 		settings.h \
-		workspace.h 
+		workspace.h \
+		rtxi_vector.h
 
 rtxi_SOURCES = \
 		atomic_fifo.cpp \
@@ -47,7 +48,7 @@ nodist_rtxi_SOURCES = \
 		config.h \
 		moc_default_gui_model.cpp \
 		moc_main_window.cpp \
-		moc_plugin.cpp 
+		moc_plugin.cpp
 
 EXTRA_DIST = \
 		rt_os-posix.cpp \

--- a/src/default_gui_model.h
+++ b/src/default_gui_model.h
@@ -268,12 +268,12 @@ protected:
      */
     void setEvent(const QString &name,double &ref);
 
-private:
-
+    // mfbolus (2021/05): Allow derived classes to access.
     void doDeferred(const Settings::Object::State &);
     void doLoad(const Settings::Object::State &);
     void doSave(Settings::Object::State &) const;
 
+private:
     void receiveEvent(const Event::Object *);
 
     bool periodEventPaused;

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <sstream>
 #include <string>
+#include <iostream> 
 
 Mutex IO::Block::mutex = Mutex(Mutex::RECURSIVE);
 
@@ -112,24 +113,34 @@ const rtxi::Vector<double>& IO::Block::getValue(IO::flags_t type,size_t n) const
         return input(n);
     if (type & OUTPUT)
         return output(n);
-    return rtxi::Vector<double>();
+    return yogi = 0.0;
 }
 
 const rtxi::Vector<double>& IO::Block::input(size_t n) const
 {
     if (unlikely(n >= inputs.size()))
-        return 0.0;
+        return yogi = 0.0;
 
-    double v = 0.0;
-    for (std::list<struct link_t>::const_iterator i = inputs[n].links.begin(),end = inputs[n].links.end(); i != end; ++i)
-        v += i->block->output(i->channel);
-    return v;
+    // double v = 0.0;
+    // for (std::list<struct link_t>::const_iterator i = inputs[n].links.begin(),end = inputs[n].links.end(); i != end; ++i)
+    //     v += i->block->output(i->channel);
+
+    // TODO(mbolus): Make sure maintainers/users are ok with this change.
+    // Previous behavior was to add together inputs if multiple linked to inputs[n] (commented above)
+    // With vectors, these different linked values could have different dimensions so addition is not viable.
+    // Instead, taking first in list.
+    if (inputs[n].links.size()) {
+        auto i = inputs[n].links.begin();
+        return i->block->output(i->channel);
+    } else {
+        return yogi = 0.0;
+    }
 }
 
 const rtxi::Vector<double>& IO::Block::output(size_t n) const
 {
     if (unlikely(n >= outputs.size()))
-        return 0.0;
+        return yogi = 0.0;
     return outputs[n].value;
 }
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -57,7 +57,7 @@ IO::Block::Block(std::string n,IO::channel_t *channel,size_t size):name(n)
             {
                 outputs[out].name = channel[i].name;
                 outputs[out].description = channel[i].description;
-                outputs[out++].value = 0.0;
+                outputs[out++].value = rtxi::Vector<double>();// fills with 0
             }
 
     IO::Connector::getInstance()->insertBlock(this);
@@ -106,16 +106,16 @@ std::string IO::Block::getDescription(IO::flags_t type,size_t n) const
     return "";
 }
 
-double IO::Block::getValue(IO::flags_t type,size_t n) const
+const rtxi::Vector<double>& IO::Block::getValue(IO::flags_t type,size_t n) const
 {
     if (type & INPUT)
         return input(n);
     if (type & OUTPUT)
         return output(n);
-    return 0.0;
+    return rtxi::Vector<double>();
 }
 
-double IO::Block::input(size_t n) const
+const rtxi::Vector<double>& IO::Block::input(size_t n) const
 {
     if (unlikely(n >= inputs.size()))
         return 0.0;
@@ -126,16 +126,16 @@ double IO::Block::input(size_t n) const
     return v;
 }
 
-double IO::Block::output(size_t n) const
+const rtxi::Vector<double>& IO::Block::output(size_t n) const
 {
     if (unlikely(n >= outputs.size()))
         return 0.0;
     return outputs[n].value;
 }
 
-double IO::Block::yogi = 0.0;
+rtxi::Vector<double> IO::Block::yogi = 0.0;
 
-double &IO::Block::output(size_t n)
+rtxi::Vector<double>& IO::Block::output(size_t n)
 {
 
     /*********************************************************

--- a/src/io.h
+++ b/src/io.h
@@ -278,6 +278,13 @@ protected:
      */
     rtxi::Vector<double>& output(size_t index);
 
+    /*************************************************************
+     * yogi exists because "double &output(size_t n)" has to     *
+     *   return a reference to something if n >= outputs.size(). *
+     *************************************************************/
+
+    static rtxi::Vector<double> yogi;
+    
 private:
 
     struct input_t;
@@ -294,13 +301,6 @@ private:
     static Mutex mutex;
     static void connect(Block *,size_t,Block *,size_t);
     static void disconnect(Block *,size_t,Block *,size_t);
-
-    /*************************************************************
-     * yogi exists because "double &output(size_t n)" has to     *
-     *   return a reference to something if n >= outputs.size(). *
-     *************************************************************/
-
-    static rtxi::Vector<double> yogi;
 
     struct link_t
     {

--- a/src/io.h
+++ b/src/io.h
@@ -245,7 +245,7 @@ public:
      * \param index The channel's index.
      * \return The value of the channel.
      */
-    virtual double getValue(flags_t type,size_t index) const;
+    virtual const rtxi::Vector<double>& getValue(flags_t type,size_t index) const;
 
     /*!
      * Get the value of the specified input channel.
@@ -253,7 +253,7 @@ public:
      * \param index The input channel's index.
      * \return The value of the specified input channel.
      */
-    double input(size_t index) const;
+    const rtxi::Vector<double>& input(size_t index) const;
     /*!
      * Get the value of the specified output channel.
      *
@@ -262,7 +262,7 @@ public:
      *
      * \sa IO::Block::output()
      */
-    double output(size_t index) const;
+    const rtxi::Vector<double>& output(size_t index) const;
 
 protected:
 
@@ -275,7 +275,7 @@ protected:
      *
      * \sa IO::Block::output()
      */
-    double &output(size_t index);
+    rtxi::Vector<double>& output(size_t index);
 
 private:
 
@@ -318,7 +318,7 @@ private:
     {
         std::string name;
         std::string description;
-        double value;
+        rtxi::Vector<double> value;
         std::list<struct link_t> links;
     };
 

--- a/src/io.h
+++ b/src/io.h
@@ -25,6 +25,7 @@
 #include <settings.h>
 #include <string>
 #include <vector>
+#include <rtxi_vector.h>
 
 //! Connection Oriented Classes
 /*!
@@ -299,7 +300,7 @@ private:
      *   return a reference to something if n >= outputs.size(). *
      *************************************************************/
 
-    static double yogi;
+    static rtxi::Vector<double> yogi;
 
     struct link_t
     {

--- a/src/rtxi_vector.h
+++ b/src/rtxi_vector.h
@@ -1,0 +1,47 @@
+/*
+         The Real-Time eXperiment Interface (RTXI)
+         Copyright (C) 2011 Georgia Institute of Technology, University of Utah,
+         Weill Cornell Medical College
+
+         Copyright (C) 2021 Michael Bolus
+
+         This program is free software: you can redistribute it and/or modify
+         it under the terms of the GNU General Public License as published by
+         the Free Software Foundation, either version 3 of the License, or
+         (at your option) any later version.
+
+         This program is distributed in the hope that it will be useful,
+         but WITHOUT ANY WARRANTY; without even the implied warranty of
+         MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+         GNU General Public License for more details.
+
+         You should have received a copy of the GNU General Public License
+         along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#ifndef RTXI_VECTOR_H
+#define RTXI_VECTOR_H
+
+#include <vector>
+
+namespace rtxi {
+
+template <typename T = double>
+class Vector : public std::vector<T> {
+ public:
+  using std::vector<T>::vector;
+  using std::vector<T>::operator=;
+  using std::vector<T>::at;
+
+  Vector(size_t n=1, T fill=0): std::vector<T>(n, fill) {};
+
+  /// conversion: T -> vector
+  Vector(T in) : std::vector<T>(1, in) {};
+  /// conversion: vector -> double
+  operator T() const { return this->at(0); };
+};
+
+}  // namespace rtxi
+
+#endif  // RTXI_VECTOR_H

--- a/src/rtxi_vector.h
+++ b/src/rtxi_vector.h
@@ -34,7 +34,7 @@ class Vector : public std::vector<T> {
   using std::vector<T>::operator=;
   using std::vector<T>::at;
 
-  Vector(size_t n=1, T fill=0): std::vector<T>(n, fill) {};
+  explicit Vector(size_t n=1, T fill=0): std::vector<T>(n, fill) {};
 
   /// conversion: T -> vector
   Vector(T in) : std::vector<T>(1, in) {};

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -179,7 +179,7 @@ std::string Workspace::Instance::getDescription(IO::flags_t type,size_t n) const
     return "";
 }
 
-double Workspace::Instance::getValue(IO::flags_t type,size_t n) const
+const rtxi::Vector<double>& Workspace::Instance::getValue(IO::flags_t type,size_t n) const
 {
     if (type & INPUT)
         return input(n);

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -186,19 +186,19 @@ const rtxi::Vector<double>& Workspace::Instance::getValue(IO::flags_t type,size_
     if (type & OUTPUT)
         return output(n);
     if (type & PARAMETER && n < parameter.size() && parameter[n].data)
-        return *parameter[n].data;
+        return yogi = *parameter[n].data;
     if (type & STATE && n < state.size() && state[n].data)
-        return *state[n].data;
+        return yogi = *state[n].data;
     if (type & EVENT && n < event.size() && event[n].data)
-        return *event[n].data;
+        return yogi = *event[n].data;
     if (type & COMMENT && n < comment.size())
         {
             std::istringstream sstr(comment[n].comment);
             double value;
             sstr >> value;
-            return value;
+            return yogi = value;
         }
-    return 0.0;
+    return yogi = 0.0;
 }
 
 std::string Workspace::Instance::getValueString(IO::flags_t type,size_t n) const

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -135,7 +135,7 @@ public:
      * \sa IO::Block::getValue()
      * \sa Workspace::setData()
      */
-    double getValue(IO::flags_t type,size_t index) const;
+    const rtxi::Vector<double>& getValue(IO::flags_t type,size_t index) const;
     /*!
      * Get the value of the specified EVENT, PARAMETER, STATE,
      *   or COMMENT variable in string form.


### PR DESCRIPTION
This PR patches RTXI to allow passing not only single values but multi-channel values (vectors) between IO blocks. It is achieved by using a thin wrapper around `std::vector<T>` (`rtxi::Vector<T>`) with converting constructors necessary for backward compatibility. In cases where a consumer calls for a `double`, the 0th element of the vector is returned. Similarly, when a producer supplies a `double`, a single-element vector with this value is constructed. There will naturally be more overhead with this method than simply passing doubles between IO blocks, but hopefully the gains outweigh the cost.

I was not sure where to put this vector class definition, so the template currently lives in its own header (`src/rtxi_vector.h`) and is enveloped by a new namespace called `rtxi`. Please feel free to edit to taste/style.

One of the main cons with this approach is that such a dynamically allocated container can be a source of potential issues if dimensions are changed at runtime. Currently, the user must take precautions to ensure dimensions do not change. Hopefully in the future end-users can be freed of this burden, but I do not currently have a solution. 
