### PR TITLE
Check both source and destination blocks for devices when doing cycle…

### DIFF
--- a/src/rt.cpp
+++ b/src/rt.cpp
@@ -34,7 +34,7 @@
 int RT::Connector::find_cycle(RT::block_connection_t conn, IO::Block* ref_block)
 {
   // devices can be connected recursively
-  if (!ref_block->dependent()) {
+  if (!conn.src->dependent() || !conn.dest->dependent()) {
     return 0;
   }
   // Cannot connect a block with itself


### PR DESCRIPTION
this further fixes #158 