### PR TITLE
Add curve styles(Lines, Dots) to oscilloscope

### DIFF
--- a/plugins/oscilloscope/oscilloscope.cpp
+++ b/plugins/oscilloscope/oscilloscope.cpp
@@ -88,6 +88,12 @@ void Oscilloscope::Panel::updateChannelPen(IO::endpoint endpoint)
   this->scopeWindow->setChannelPen(endpoint, pen);
 }
 
+void Oscilloscope::Panel::updateChannelCurveStyle(IO::endpoint endpoint)
+{
+  auto curveStyle = this->curveStylesList->currentData().value<QwtPlotCurve::CurveStyle>();
+  this->scopeWindow->setChannelCurveStyle(endpoint, curveStyle);
+}
+
 void Oscilloscope::Panel::updateChannelLabel(IO::endpoint probe_info)
 {
   const QString chanlabel = QString::number(probe_info.block->getID()) + " "
@@ -135,6 +141,7 @@ void Oscilloscope::Panel::enableChannel()
   this->updateChannelOffset(endpoint);
   this->updateChannelScale(endpoint);
   this->updateChannelPen(endpoint);
+  this->updateChannelCurveStyle(endpoint);
 }
 
 void Oscilloscope::Panel::disableChannel()
@@ -166,6 +173,7 @@ void Oscilloscope::Panel::activateChannel(bool active)
   colorsList->setEnabled(enable);
   widthsList->setEnabled(enable);
   stylesList->setEnabled(enable);
+  curveStylesList->setEnabled(enable);
   this->activateButton->setChecked(enable);
 }
 
@@ -254,6 +262,7 @@ void Oscilloscope::Panel::applyChannelTab()
     this->updateChannelScale(probeInfo);
     this->updateChannelOffset(probeInfo);
     this->updateChannelPen(probeInfo);
+    this->updateChannelCurveStyle(probeInfo);
     this->updateChannelLabel(probeInfo);
   }
   scopeWindow->replot();
@@ -431,7 +440,7 @@ QWidget* Oscilloscope::Panel::createChannelTab(QWidget* parent)
   }
 
   // Create styles list
-  auto* styleLabel = new QLabel(tr("Style:"), page);
+  auto* styleLabel = new QLabel(tr("Line Style:"), page);
   row2Layout->addWidget(styleLabel);
   stylesList = new QComboBox(page);
   stylesList->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
@@ -449,6 +458,25 @@ QWidget* Oscilloscope::Panel::createChannelTab(QWidget* parent)
     stylesList->addItem(tmp,
                         QString(temp_name.c_str()),
                         QVariant::fromValue(Oscilloscope::penStyles.at(i)));
+  }
+
+  // Create curve styles list
+  auto* curveStyleLabel = new QLabel(tr("Curve Style:"), page);
+  row2Layout->addWidget(curveStyleLabel);
+  curveStylesList = new QComboBox(page);
+  curveStylesList->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+  curveStylesList->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+  row2Layout->addWidget(curveStylesList);
+  for (size_t i = 0; i < Oscilloscope::curveStyles.size(); i++) {
+    temp_name = Oscilloscope::curvestyles2string.at(i);
+    tmp.fill(Qt::white);
+    painter.setPen(
+      QPen(Oscilloscope::penColors.at(Oscilloscope::ColorID::Black),
+      3));
+    (i == 0) ? painter.drawLine(0, 12, 25, 12) : painter.drawPoint(12, 12);
+    curveStylesList->addItem(tmp,
+                        QString(temp_name.c_str()),
+                        QVariant::fromValue(Oscilloscope::curveStyles.at(i)));
   }
 
   // Activate button

--- a/plugins/oscilloscope/oscilloscope.cpp
+++ b/plugins/oscilloscope/oscilloscope.cpp
@@ -938,6 +938,8 @@ void Oscilloscope::Panel::syncChannelProperties()
   widthsList->setCurrentIndex(widthsList->findData(width));
   const Qt::PenStyle style = scopeWindow->getChannelStyle(probe_info);
   stylesList->setCurrentIndex(stylesList->findData(QVariant::fromValue(style)));
+  const QwtPlotCurve::CurveStyle curveStyle = scopeWindow->getChannelCurveStyle(probe_info);
+  curveStylesList->setCurrentIndex(curveStylesList->findData(QVariant::fromValue(curveStyle)));
   double offset = scopeWindow->getChannelOffset(probe_info);
   const double scale = scopeWindow->getChannelScale(probe_info);
   scalesList->setCurrentIndex(

--- a/plugins/oscilloscope/oscilloscope.hpp
+++ b/plugins/oscilloscope/oscilloscope.hpp
@@ -127,6 +127,7 @@ private:
   void updateChannelScale(IO::endpoint probe_info);
   void updateChannelOffset(IO::endpoint probe_info);
   void updateChannelPen(IO::endpoint endpoint);
+  void updateChannelCurveStyle(IO::endpoint endpoint);
   void updateWindowTimeDiv();
 
   // Tab Widget
@@ -170,6 +171,7 @@ private:
   QComboBox* offsetsList = nullptr;
   QComboBox* scalesList = nullptr;
   QComboBox* stylesList = nullptr;
+  QComboBox* curveStylesList = nullptr;
   QComboBox* widthsList = nullptr;
   QLineEdit* offsetsEdit = nullptr;
 

--- a/plugins/oscilloscope/scope.cpp
+++ b/plugins/oscilloscope/scope.cpp
@@ -421,6 +421,19 @@ Qt::PenStyle Oscilloscope::Scope::getChannelStyle(IO::endpoint endpoint)
   return chan_loc->curve->pen().style();
 }
 
+QwtPlotCurve::CurveStyle Oscilloscope::Scope::getChannelCurveStyle(IO::endpoint endpoint)
+{
+  const std::shared_lock<std::shared_mutex> lock(this->m_channel_mutex);
+  auto chan_loc = std::find_if(this->channels.begin(),
+                               this->channels.end(),
+                               [&](const Oscilloscope::scope_channel& chann)
+                               { return chann.endpoint == endpoint; });
+  if (chan_loc == channels.end()) {
+    return curveStyles[Oscilloscope::CurveStyleID::Line];
+  }
+  return chan_loc->curve->style();
+}
+
 int Oscilloscope::Scope::getChannelWidth(IO::endpoint endpoint)
 {
   const std::shared_lock<std::shared_mutex> lock(this->m_channel_mutex);

--- a/plugins/oscilloscope/scope.cpp
+++ b/plugins/oscilloscope/scope.cpp
@@ -194,6 +194,7 @@ void Oscilloscope::Scope::createChannel(IO::endpoint probeInfo,
   pen.setStyle(Oscilloscope::penStyles[0]);
   chan.fifo = fifo;
   chan.curve->setPen(pen);
+  chan.curve->setStyle(Oscilloscope::curveStyles[0]);
   chan.curve->attach(this);
   this->channels.push_back(chan);
 }
@@ -442,6 +443,18 @@ void Oscilloscope::Scope::setChannelPen(IO::endpoint endpoint, const QPen& pen)
                                { return chann.endpoint == endpoint; });
   if (chan_loc != channels.end()) {
     chan_loc->curve->setPen(pen);
+  }
+}
+
+void Oscilloscope::Scope::setChannelCurveStyle(IO::endpoint endpoint, const QwtPlotCurve::CurveStyle& curveStyle)
+{
+  const std::shared_lock<std::shared_mutex> lock(this->m_channel_mutex);
+  auto chan_loc = std::find_if(this->channels.begin(),
+                               this->channels.end(),
+                               [&](const Oscilloscope::scope_channel& chann)
+                               { return chann.endpoint == endpoint; });
+  if (chan_loc != channels.end()) {
+    chan_loc->curve->setStyle(curveStyle);
   }
 }
 

--- a/plugins/oscilloscope/scope.hpp
+++ b/plugins/oscilloscope/scope.hpp
@@ -214,6 +214,7 @@ public:
   void setChannelLabel(IO::endpoint endpoint, const QString& label);
   QColor getChannelColor(IO::endpoint endpoint);
   Qt::PenStyle getChannelStyle(IO::endpoint endpoint);
+  QwtPlotCurve::CurveStyle getChannelCurveStyle(IO::endpoint endpoint);
   void setChannelPen(IO::endpoint endpoint, const QPen& pen);
   void setChannelCurveStyle(IO::endpoint endpoint, const QwtPlotCurve::CurveStyle& curveStyle);
   int getChannelWidth(IO::endpoint endpoint);

--- a/plugins/oscilloscope/scope.hpp
+++ b/plugins/oscilloscope/scope.hpp
@@ -34,6 +34,7 @@
 #include <shared_mutex>
 #include <vector>
 
+#include <qwt_plot_curve.h>
 #include <qwt_plot_canvas.h>
 #include <qwt_plot_legenditem.h>
 #include <qwt_plot.h>
@@ -143,6 +144,21 @@ enum penstyle_id : size_t
 };
 }  // namespace PenStyleID
 
+constexpr std::array<QwtPlotCurve::CurveStyle, 2> curveStyles = {QwtPlotCurve::Lines, QwtPlotCurve::Dots};
+
+constexpr std::array<std::string_view, 2> curvestyles2string {
+    "Lines", "Dots"};
+
+namespace CurveStyleID
+{
+enum curvestyle_id : size_t
+{
+  Line = 0,
+  Dot,
+};
+}  // namespace CurveStyleID
+
+
 class LegendItem : public QwtPlotLegendItem
 {
 public:
@@ -199,6 +215,7 @@ public:
   QColor getChannelColor(IO::endpoint endpoint);
   Qt::PenStyle getChannelStyle(IO::endpoint endpoint);
   void setChannelPen(IO::endpoint endpoint, const QPen& pen);
+  void setChannelCurveStyle(IO::endpoint endpoint, const QwtPlotCurve::CurveStyle& curveStyle);
   int getChannelWidth(IO::endpoint endpoint);
   double getTriggerThreshold() const;
   void setTriggerThreshold(double threshold);
@@ -252,4 +269,5 @@ private:
 
 }  // namespace Oscilloscope
 
+Q_DECLARE_METATYPE(QwtPlotCurve::CurveStyle)
 #endif  // SCOPE_H


### PR DESCRIPTION
According to [documentation](https://qwt.sourceforge.io/class_qwt_plot_curve.html#a15998aa80a11ba6ba80eebabaf773f70) QwtPlotCurve::Dots,  "**FASTER**"

So, QwtPlotCurve::Dots added as a curve style option to produce scatter plot in oscilloscope