### PR TITLE
Fix save connections

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -80,11 +80,11 @@ QDataStream& operator<<(QDataStream& out, const plugin_connection& conn)
 
 QDataStream& operator>>(QDataStream& in, plugin_connection& conn)
 {
-  in >> conn.dest_port;
-  in >> conn.dest_id;
-  in >> conn.src_port;
+  in >> conn.src_id;          // Match order of << operator
   in >> conn.src_direction;
-  in >> conn.src_id;
+  in >> conn.src_port;
+  in >> conn.dest_id;
+  in >> conn.dest_port;
   return in;
 }
 
@@ -725,7 +725,7 @@ void MainWindow::saveConnectionSettings(QSettings& userprefs)
     // themselves. Namely connections related to probes from oscilloscope and
     // recorders from the recorder plugin
     if (conn.dest->getName().find("Probe") != std::string::npos
-        || conn.dest->getName().find("Recording") != std::string::npos)
+    || conn.dest->getName().find("Recording") != std::string::npos)
     {
       continue;
     }
@@ -760,7 +760,7 @@ void MainWindow::loadConnectionSettings(
     }
     connection.src = block_cache[id_connection.src_id];
     connection.src_port_type =
-        static_cast<IO::flags_t>(id_connection.src_direction);
+    static_cast<IO::flags_t>(id_connection.src_direction);
     connection.src_port = id_connection.src_port;
     connection.dest = block_cache[id_connection.dest_id];
     connection.dest_port = id_connection.dest_port;

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -534,7 +534,7 @@ void MainWindow::saveDAQSettings(QSettings& userprefs)
 }
 
 void MainWindow::loadDAQSettings(
-    QSettings& userprefs, std::unordered_map<size_t, IO::Block*> block_cache)
+    QSettings& userprefs, std::unordered_map<size_t, IO::Block*>& block_cache)
 {
   userprefs.beginGroup("DAQs");
   Event::Object get_devices_event(Event::Type::DAQ_DEVICE_QUERY_EVENT);
@@ -664,9 +664,8 @@ void MainWindow::saveWidgetSettings(QSettings& userprefs)
   this->event_manager->postEvent(&loaded_plugins_query);
   const auto plugin_list = std::any_cast<std::vector<const Widgets::Plugin*>>(
       loaded_plugins_query.getParam("plugins"));
-  int widget_count = 0;
   for (const auto& entry : plugin_list) {
-    userprefs.beginGroup(QString::number(widget_count++));
+    userprefs.beginGroup(QString::number(entry->getID()));
     userprefs.setValue("library", QString::fromStdString(entry->getLibrary()));
     userprefs.beginGroup("standardParams");
     entry->saveParameterSettings(userprefs);
@@ -680,7 +679,7 @@ void MainWindow::saveWidgetSettings(QSettings& userprefs)
 }
 
 void MainWindow::loadWidgetSettings(
-    QSettings& userprefs, std::unordered_map<size_t, IO::Block*> block_cache)
+    QSettings& userprefs, std::unordered_map<size_t, IO::Block*>& block_cache)
 {
   userprefs.beginGroup("Widgets");
   QString plugin_name;
@@ -734,7 +733,7 @@ void MainWindow::saveConnectionSettings(QSettings& userprefs)
 }
 
 void MainWindow::loadConnectionSettings(
-    QSettings& userprefs, std::unordered_map<size_t, IO::Block*> block_cache)
+    QSettings& userprefs, std::unordered_map<size_t, IO::Block*>& block_cache)
 {
   ///////////////////// Load connections /////////////////////////
   RT::block_connection_t connection;

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -725,7 +725,7 @@ void MainWindow::saveConnectionSettings(QSettings& userprefs)
     // themselves. Namely connections related to probes from oscilloscope and
     // recorders from the recorder plugin
     if (conn.dest->getName().find("Probe") != std::string::npos
-    || conn.dest->getName().find("Recording") != std::string::npos)
+        || conn.dest->getName().find("Recording") != std::string::npos)
     {
       continue;
     }
@@ -760,7 +760,7 @@ void MainWindow::loadConnectionSettings(
     }
     connection.src = block_cache[id_connection.src_id];
     connection.src_port_type =
-    static_cast<IO::flags_t>(id_connection.src_direction);
+        static_cast<IO::flags_t>(id_connection.src_direction);
     connection.src_port = id_connection.src_port;
     connection.dest = block_cache[id_connection.dest_id];
     connection.dest_port = id_connection.dest_port;

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -665,6 +665,14 @@ void MainWindow::saveWidgetSettings(QSettings& userprefs)
   const auto plugin_list = std::any_cast<std::vector<const Widgets::Plugin*>>(
       loaded_plugins_query.getParam("plugins"));
   for (const auto& entry : plugin_list) {
+    // entry->getID, 0 index occupied by a System Plugin
+    // block_cache[0]  0 index occupied by the Device
+    // connections from 0(device) to any plugin will crash. 
+    // So skip the 0 index in widgets, don't save System Plugins   
+    if (entry->getID() == 0) 
+    {
+      continue;
+    }
     userprefs.beginGroup(QString::number(entry->getID()));
     userprefs.setValue("library", QString::fromStdString(entry->getLibrary()));
     userprefs.beginGroup("standardParams");

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -836,6 +836,8 @@ void MainWindow::saveSettings()
   this->saveDAQSettings(workspaceprefs);
 
   this->saveWidgetSettings(workspaceprefs);
+  
+  this->saveConnectionSettings(workspaceprefs);
 
   userprefs.endGroup();  // Workspaces
 }

--- a/src/main_window.hpp
+++ b/src/main_window.hpp
@@ -178,13 +178,13 @@ private:
   inline void loadPeriodSettings(QSettings& userprefs);
   inline void saveDAQSettings(QSettings& userprefs);
   inline void loadDAQSettings(
-      QSettings& userprefs, std::unordered_map<size_t, IO::Block*> block_cache);
+      QSettings& userprefs, std::unordered_map<size_t, IO::Block*>& block_cache);
   inline void saveWidgetSettings(QSettings& userprefs);
   inline void loadWidgetSettings(
-      QSettings& userprefs, std::unordered_map<size_t, IO::Block*> block_cache);
+      QSettings& userprefs, std::unordered_map<size_t, IO::Block*>& block_cache);
   inline void saveConnectionSettings(QSettings& userprefs);
   inline void loadConnectionSettings(
-      QSettings& userprefs, std::unordered_map<size_t, IO::Block*> block_cache);
+      QSettings& userprefs, std::unordered_map<size_t, IO::Block*>& block_cache);
   Event::Manager* event_manager;
   QMdiArea* mdiArea = nullptr;
   QList<QMdiSubWindow*> subWindows;


### PR DESCRIPTION
### Changes to settings and connections handling:

* [`src/main_window.cpp`](diffhunk://#diff-b3ed26d65c5ac5df94b6643069fb7cc794d8781d314cea585f7d3349632bb299L83-R87): Fixed the order of fields in the `QDataStream& operator>>(QDataStream& in, plugin_connection& conn)` function to match the order in the `<<` operator.

* [`src/main_window.cpp`](diffhunk://#diff-b3ed26d65c5ac5df94b6643069fb7cc794d8781d314cea585f7d3349632bb299L537-R537): Modified the `block_cache` parameter in `loadDAQSettings`, `loadWidgetSettings`, and `loadConnectionSettings` to be passed by reference instead of by value. [[1]](diffhunk://#diff-b3ed26d65c5ac5df94b6643069fb7cc794d8781d314cea585f7d3349632bb299L537-R537) [[2]](diffhunk://#diff-b3ed26d65c5ac5df94b6643069fb7cc794d8781d314cea585f7d3349632bb299L683-R690) [[3]](diffhunk://#diff-b3ed26d65c5ac5df94b6643069fb7cc794d8781d314cea585f7d3349632bb299L737-R744)

* [`src/main_window.cpp`](diffhunk://#diff-b3ed26d65c5ac5df94b6643069fb7cc794d8781d314cea585f7d3349632bb299L667-R676): Updated the logic in `saveWidgetSettings` to skip saving system plugins, preventing crashes due to connections from the device to any plugin.

* [`src/main_window.cpp`](diffhunk://#diff-b3ed26d65c5ac5df94b6643069fb7cc794d8781d314cea585f7d3349632bb299R847-R848): Added a call to `saveConnectionSettings` in the `saveSettings` function to ensure connection settings are saved.

* [`src/main_window.hpp`](diffhunk://#diff-43c87d369b75ca6082c0f8c28c7b798d02577e1c72ee38ca8b60d23e7f7320e3L181-R187): Updated the function declarations to reflect the changes in the `block_cache` parameter being passed by reference.