### PR TITLE
Connector Check Cycle button

### DIFF
--- a/plugins/connector/connector.cpp
+++ b/plugins/connector/connector.cpp
@@ -31,6 +31,7 @@
 Connector::Panel::Panel(QMainWindow* mw, Event::Manager* ev_manager)
     : Widgets::Panel(std::string(Connector::MODULE_NAME), mw, ev_manager)
     , buttonGroup(new QGroupBox)
+    , checkCycleButton(new QPushButton)
     , inputBlock(new QComboBox)
     , inputChannel(new QComboBox)
     , outputBlock(new QComboBox)
@@ -105,6 +106,12 @@ Connector::Panel::Panel(QMainWindow* mw, Event::Manager* ev_manager)
                    &QPushButton::clicked,
                    this,
                    &Connector::Panel::toggleConnection);
+
+  // Create elements for button
+  checkCycleButton->setText("Check Cycle");
+  checkCycleButton->setCheckable(true);
+  checkCycleButton->setChecked(true);  // Default: activated
+  buttonLayout->addWidget(checkCycleButton);
 
   // Assign layout to child widget
   buttonGroup->setLayout(buttonLayout);
@@ -343,6 +350,8 @@ void Connector::Panel::highlightConnectionBox(const QString& /*item*/)
   const QVariant src_chan_variant = this->outputChannel->currentData();
   const QVariant dest_variant = this->inputBlock->currentData();
   const QVariant dest_chan_variant = this->inputChannel->currentData();
+  bool check_cycle = this->checkCycleButton->isChecked();
+
   if (!src_variant.isValid() || !src_type_variant.isValid()
       || !dest_variant.isValid() || !src_chan_variant.isValid()
       || !dest_chan_variant.isValid())
@@ -357,6 +366,7 @@ void Connector::Panel::highlightConnectionBox(const QString& /*item*/)
   current_connection.src_port = src_chan_variant.value<size_t>();
   current_connection.dest = dest_variant.value<IO::Block*>();
   current_connection.dest_port = dest_chan_variant.value<size_t>();
+  current_connection.check_cycle = check_cycle;
   QVariant temp_conn_variant;
   // update connection button state
   for (int row = 0; row < connectionBox->count(); ++row) {
@@ -398,6 +408,8 @@ void Connector::Panel::toggleConnection(bool down)
   const QVariant src_port = outputChannel->currentData();
   const QVariant dest_block = inputBlock->currentData();
   const QVariant dest_port = inputChannel->currentData();
+  bool check_cycle = this->checkCycleButton->isChecked();
+
   if (!src_block.isValid() || !src_type.isValid() || !src_port.isValid()
       || !dest_block.isValid() || !dest_port.isValid())
   {
@@ -412,6 +424,7 @@ void Connector::Panel::toggleConnection(bool down)
   connection.src_port = src_port.value<size_t>();
   connection.dest = dest_block.value<IO::Block*>();
   connection.dest_port = dest_port.value<size_t>();
+  connection.check_cycle = check_cycle;
 
   if (down) {
     Event::Object event(Event::Type::IO_LINK_INSERT_EVENT);
@@ -440,6 +453,7 @@ void Connector::Panel::updateConnectionButton()
   const QVariant src_port = outputChannel->currentData();
   const QVariant dest_block = inputBlock->currentData();
   const QVariant dest_port = inputChannel->currentData();
+  bool check_cycle = checkCycleButton->isChecked();
   if (!src_block.isValid() || !src_type.isValid() || !src_port.isValid()
       || !dest_block.isValid() || !dest_port.isValid())
   {
@@ -455,6 +469,7 @@ void Connector::Panel::updateConnectionButton()
   connection.src_port = src_port.value<size_t>();
   connection.dest = dest_block.value<IO::Block*>();
   connection.dest_port = dest_port.value<size_t>();
+  connection.check_cycle = check_cycle;
 
   QListWidgetItem* temp_item = nullptr;
   for (int i = 0; i < connectionBox->count(); i++) {

--- a/plugins/connector/connector.hpp
+++ b/plugins/connector/connector.hpp
@@ -71,6 +71,7 @@ private:
   QComboBox* outputChannel;
   QListWidget* connectionBox;
   QPushButton* connectionButton;
+  QPushButton* checkCycleButton;
   std::vector<IO::Block*> blocks;
   std::vector<RT::block_connection_t> links;
 };  // class Panel

--- a/src/rt.cpp
+++ b/src/rt.cpp
@@ -62,7 +62,9 @@ int RT::Connector::connect(RT::block_connection_t connection)
         "RT::Connector : source or destination blocks are not registered");
     return -1;
   }
-  if (this->find_cycle(connection, connection.src) == -1) {
+  if (connection.check_cycle
+      && this->find_cycle(connection, connection.src) == -1)
+  {
     ERROR_MSG("RT::Connector : The Connection would have caused a cycle");
     return -1;
   }
@@ -248,12 +250,12 @@ void RT::Connector::propagateBlockConnections(IO::Block* block)
 void RT::Connector::clearAllConnections(IO::Block* block)
 {
   for (auto& entry : this->connections) {
-    entry.erase(std::remove_if(entry.begin(),
-                               entry.end(),
-                               [&](RT::block_connection_t conn) {
-                                 return conn.dest == block || conn.src == block;
-                               }),
-                entry.end());
+    entry.erase(
+        std::remove_if(entry.begin(),
+                       entry.end(),
+                       [&](RT::block_connection_t conn)
+                       { return conn.dest == block || conn.src == block; }),
+        entry.end());
   }
 }
 

--- a/src/rt.hpp
+++ b/src/rt.hpp
@@ -185,6 +185,7 @@ public:
  * \param src_port Index of the source channel generating the output
  * \param dest IO::Block pointer representing who to send the output to
  * \param dest_port Index of the destination channel taking the output as input
+ * \param check_cycle Whether or not to check for cycles
  */
 typedef struct block_connection_t
 {
@@ -193,6 +194,7 @@ typedef struct block_connection_t
   size_t src_port = 0;
   IO::Block* dest = nullptr;
   size_t dest_port = 0;
+  bool check_cycle = false;
   bool operator==(const block_connection_t& rhs) const
   {
     return (this->src == rhs.src) && (this->src_port_type == rhs.src_port_type)


### PR DESCRIPTION
# Connector Check Cycle button

## Summary
Some plugins used in the lab may require a cycle in the connection graph, which the system typically prevents to avoid instability. To support these use cases, I implemented a **"Check Cycle"** toggle button in the **Connector** panel UI, along with a new `check_cycle` attribute in the `block_connection_t` structure.

## Details
- Added a `QPushButton` labeled **"Check Cycle"** next to the **"Connect"** button in the Connector panel.
- The button is checkable and defaults to `true`, meaning cycle checking is enabled by default.
- When a connection is created, the current state of this button is stored in the `check_cycle` flag of the corresponding `block_connection_t`.
- This flag can later be retrieved from the `connectionBox` to determine whether cycle checking was requested for a given connection, but it does not restore the state of the button itself.

## Example of Cycle
In my university's lab, they tend to make this kind of connection.

![connection_cycle](https://github.com/user-attachments/assets/1598ffb6-b15c-4d77-a785-dc9f542219ac)

As it can be seen the connection goes like:

 ```mermaid
---
config:
  theme: mc
  look: classic
  layout: dagre
---
flowchart TD
    n1(["Hindmarsh-Rose Neuron"]) -- "Post-Synaptic Voltage" --> A(["Electrical Synapse"])
    n2(["Hindmarsh-Rose Neuron"]) -- "Pre-Synaptic Voltage" --> A
    A -- Synaptic Current --> n1

 ``` 
 
> [!NOTE]  
> This pull request is independent of the `preempt-rt` one.

Thank you for reviewing this pull request!
